### PR TITLE
fix "error: redefinition of typedef ‘domid_t’"

### DIFF
--- a/drivers/xen/vgt/vgt-if.h
+++ b/drivers/xen/vgt/vgt-if.h
@@ -233,7 +233,7 @@ static inline void vgt_exit(int cpu)
 #define XEN_IGD_MAX     3   /* the max GEN dev type supported */
 
 /* from "include/xen/interface/xen.h" */
-typedef uint16_t domid_t;
+/*typedef uint16_t domid_t;*/
 
 static inline bool kvm_guest_domain(void)
 {


### PR DESCRIPTION
fix "error: redefinition of typedef ‘domid_t’"

domid_t had defined in include/xen/interface/xen.h ,so when comple it will raise redefine error.
